### PR TITLE
Feature: Footnote Shortcode

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -898,3 +898,109 @@ dialog.modal[open] {
 #articles {
   transition: opacity 0.01s;
 }
+
+/* ============================================================================
+   FOOTNOTE POPOVER
+   Inline info icon with popover content using the Popover API + CSS Anchor
+   ============================================================================ */
+
+.footnote-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--color-info);
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  vertical-align: baseline;
+  transition: opacity 0.15s ease-out;
+}
+
+.footnote-trigger:hover {
+  opacity: 0.7;
+}
+
+.footnote-trigger > span {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+}
+
+/* Popover styling with anchor positioning */
+.footnote-content {
+  width: 16rem;
+  padding: 0.75rem;
+  background-color: var(--color-base-100);
+  border: 1px solid var(--color-base-300);
+  border-radius: var(--radius-box);
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  /* Anchor positioning */
+  position-area: top;
+  position-try-fallbacks: flip-block;
+  margin-bottom: 0.5rem;
+}
+
+.footnote-title {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: var(--color-base-content);
+}
+
+.footnote-body {
+  color: var(--color-base-content);
+  opacity: 0.8;
+}
+
+.footnote-body p {
+  margin: 0;
+}
+
+.footnote-body p + p {
+  margin-top: 0.5em;
+}
+
+.footnote-body ul,
+.footnote-body ol {
+  margin: 0.25em 0;
+  padding-left: 1.25em;
+}
+
+.footnote-body ul {
+  list-style-type: disc;
+}
+
+.footnote-body ol {
+  list-style-type: decimal;
+}
+
+.footnote-body li {
+  margin: 0.125em 0;
+}
+
+.footnote-body li::marker {
+  color: var(--color-primary);
+}
+
+.footnote-body strong,
+.footnote-body b {
+  font-weight: 600;
+  color: var(--color-secondary);
+}
+
+.footnote-body em,
+.footnote-body i {
+  font-style: italic;
+}
+
+.footnote-body a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.footnote-body a:hover {
+  opacity: 0.8;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -15,6 +15,7 @@ import SwupSlideTheme from '@swup/slide-theme';
 import { initCodeCopy } from './modules/code-copy.js';
 import { initScrollspy, destroyScrollspy } from './modules/scrollspy.js';
 import { initScrollToTop } from './modules/scroll-to-top.js';
+import { initFootnotes, destroyFootnotes } from './modules/footnotes.js';
 
 // Initialize swup
 const swup = new Swup({
@@ -107,11 +108,13 @@ function initPageScripts() {
   initCodeCopy();
   initScrollspy();
   initScrollToTop(swup);
+  initFootnotes();
 }
 
 // Cleanup before content replacement
 function cleanupPageScripts() {
   destroyScrollspy();
+  destroyFootnotes();
 }
 
 // Initialize on first load

--- a/assets/js/modules/footnotes.js
+++ b/assets/js/modules/footnotes.js
@@ -1,0 +1,77 @@
+/**
+ * Footnotes Module
+ * Creates popovers from templates and handles single-open behavior
+ * Templates are used in the shortcode to avoid breaking paragraph structure
+ * (Positioning handled by CSS anchor positioning)
+ */
+
+let toggleHandler = null;
+let createdPopovers = [];
+
+/**
+ * Handle popover toggle events
+ * Close other popovers when one opens
+ */
+function handleToggle(e) {
+  const popover = e.target;
+  if (!popover.classList.contains('footnote-content')) return;
+
+  if (e.newState === 'open') {
+    // Close other open popovers
+    document.querySelectorAll('.footnote-content:popover-open').forEach((other) => {
+      if (other !== popover) {
+        other.hidePopover();
+      }
+    });
+  }
+}
+
+/**
+ * Create popovers from templates and append to body
+ * This avoids block elements breaking paragraph structure
+ * CSS anchor positioning works because it uses named anchors
+ */
+function createPopoversFromTemplates() {
+  document.querySelectorAll('template[data-footnote-template]').forEach((template) => {
+    const id = template.dataset.footnoteTemplate;
+
+    // Skip if popover already exists
+    if (document.getElementById(id)) return;
+
+    // Clone template content and append to body
+    const popover = template.content.firstElementChild.cloneNode(true);
+    document.body.appendChild(popover);
+    createdPopovers.push(popover);
+  });
+}
+
+/**
+ * Initialize footnotes
+ */
+export function initFootnotes() {
+  // Clean up first
+  destroyFootnotes();
+
+  // Create popovers from templates
+  createPopoversFromTemplates();
+
+  // Add toggle handler for single-open behavior
+  toggleHandler = handleToggle;
+  document.addEventListener('toggle', toggleHandler);
+}
+
+/**
+ * Cleanup footnotes
+ */
+export function destroyFootnotes() {
+  if (toggleHandler) {
+    document.removeEventListener('toggle', toggleHandler);
+    toggleHandler = null;
+  }
+
+  // Remove created popovers
+  createdPopovers.forEach((popover) => {
+    popover.remove();
+  });
+  createdPopovers = [];
+}

--- a/exampleSite/content/samples/footnotes.md
+++ b/exampleSite/content/samples/footnotes.md
@@ -1,0 +1,52 @@
+---
+title: "Footnotes"
+date: 2024-01-15
+description: "Demonstrating the inline footnote shortcode with dropdown functionality."
+tags: ["shortcodes", "footnotes", "ui"]
+---
+
+This page demonstrates the `footnote` shortcode, which creates inline info icons that reveal additional content when clicked.
+
+## Basic Usage
+
+Here's a sentence with a footnote at the end.{{< footnote >}}This is the footnote content that appears in the dropdown.{{< /footnote >}} The text continues normally after the footnote icon.
+
+You can also place footnotes in the middle{{< footnote >}}Like this one right here!{{< /footnote >}} of a sentence without breaking the flow.
+
+## With Custom Titles
+
+The footnote shortcode accepts an optional `title` parameter:
+
+This fact might surprise you{{< footnote title="Did you know?" >}}The first computer bug was an actual bug - a moth found in a Harvard Mark II computer in 1947.{{< /footnote >}} and change how you think about debugging.
+
+## Multiple Footnotes
+
+A paragraph can have multiple footnotes{{< footnote title="First note" >}}This is the first piece of additional information.{{< /footnote >}} scattered throughout the text{{< footnote title="Second note" >}}And here's another bit of context that might be helpful.{{< /footnote >}} to provide context without cluttering the main content.
+
+## Footnotes with Markdown Content
+
+The footnote content supports markdown formatting:
+
+Learn more about this topic{{< footnote title="Resources" >}}
+- **Bold text** works
+- *Italic text* too
+- Even [links](https://example.com) are supported
+{{< /footnote >}} in the resources section.
+
+## Use Cases
+
+Footnotes are perfect for:
+
+1. **Definitions** - Explain technical terms{{< footnote >}}A technical term is specialized vocabulary used in a particular field or profession.{{< /footnote >}} without interrupting the flow.
+2. **Citations** - Reference sources{{< footnote title="Source" >}}Smith, J. (2024). *The Art of Writing*. Publisher Name.{{< /footnote >}} inline.
+3. **Asides** - Add commentary{{< footnote >}}This is my personal opinion and may not reflect the views of others.{{< /footnote >}} that some readers might want to skip.
+4. **Clarifications** - Provide additional context{{< footnote title="Note" >}}This applies only to version 2.0 and later.{{< /footnote >}} for edge cases.
+
+## Accessibility
+
+The footnote uses proper ARIA attributes and keyboard navigation:
+
+- Click the icon to open the dropdown
+- Click elsewhere to close it
+- The `tabindex` attributes ensure keyboard accessibility
+- Screen readers will announce the tooltip title

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -60,18 +60,18 @@
         {{- end }}
 
         {{- /* Mobile Menu Toggle */ -}}
-        <details class="dropdown dropdown-end lg:hidden">
-          <summary class="btn btn-ghost btn-circle" aria-label="{{ i18n " ui.menu" | default "Menu" }}">
+        <div class="dropdown dropdown-end lg:hidden">
+          <button tabindex="0" class="btn btn-txt btn-circle" aria-label="{{ i18n " ui.menu" | default "Menu" }}">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
               stroke="currentColor" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
             </svg>
-          </summary>
-          <ul class="menu dropdown-content menu-sm z-50 mt-3 w-52 rounded-box bg-base-100 p-2 shadow-lg border border-base-300">
+          </button>
+          <ul tabindex="-1" class="menu dropdown-content menu-md z-50 mt-3 w-52 rounded-box bg-base-100 p-2 shadow-lg border border-base-300">
             {{- range site.Menus.main }}
             {{- if not (eq .Params.type "search") }}
             <li>
-              <a href="{{ .URL | relURL }}" class="{{ if $.IsMenuCurrent " main" . }}text-secondary font-semibold{{ end
+              <a href="{{ .URL | relURL }}" onclick="document.activeElement.blur()" class="{{ if $.IsMenuCurrent " main" . }}text-secondary font-semibold{{ end
                 }}">
                 {{ .Name }}
               </a>
@@ -79,7 +79,7 @@
             {{- end }}
             {{- end }}
           </ul>
-        </details>
+        </div>
       </div>
     </nav>
   </div>

--- a/layouts/shortcodes/footnote.html
+++ b/layouts/shortcodes/footnote.html
@@ -1,0 +1,18 @@
+{{- /*
+  Footnote Shortcode
+
+  Creates an inline info icon that shows a popover with additional content when clicked.
+  Uses the Popover API with CSS anchor positioning.
+  Content is in a <template> to avoid breaking paragraph structure; JS creates the popover.
+
+  Usage:
+    {{< footnote >}}Your footnote content here{{< /footnote >}}
+
+    With title:
+    {{< footnote title="Did you know?" >}}Your footnote content here{{< /footnote >}}
+*/ -}}
+{{- $title := .Get "title" | default "More info" -}}
+{{- $content := $.Page.RenderString (dict "display" "block") .Inner -}}
+{{- $id := printf "fn-%s" (substr (md5 (printf "%s%s" .Page.File.UniqueID .Inner)) 0 8) -}}
+{{- $anchor := printf "--anchor-%s" $id -}}
+<button type="button" popovertarget="{{ $id }}" class="footnote-trigger" title="{{ $title }}" style="anchor-name:{{ $anchor }}"><span class="icon-[tabler--info-square-rounded]"></span></button><template data-footnote-template="{{ $id }}"><div popover id="{{ $id }}" class="footnote-content" style="position-anchor:{{ $anchor }}">{{- if $title }}<strong class="footnote-title">{{ $title }}</strong>{{- end }}<div class="footnote-body">{{ $content }}</div></div></template>


### PR DESCRIPTION
Adds a footnote shortcode to insert a clickable info icon inline. The icon uses the popover API to display a rich-text detail card. Also fixes a bug with the mobile menu not closing on click.
Satisfies #28 